### PR TITLE
Convert luthersystems/substratecommon to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,0 @@
-version: 2
-jobs:
-  build:
-    docker:
-      - image: luthersystems/build-go:0.0.51
-    steps:
-      - checkout
-      - run: echo $LUTHER_LICENSE | base64 -d > .luther-license.yaml
-      - run: make citest

--- a/.github/workflows/substratecommon.yml
+++ b/.github/workflows/substratecommon.yml
@@ -1,0 +1,16 @@
+name: luthersystems/substratecommon/luthersystems/substratecommon
+on:
+  push:
+    branches:
+    - main
+env:
+  LUTHER_LICENSE: xxxxTT0K
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: luthersystems/build-go:0.0.51
+    steps:
+    - uses: actions/checkout@v3.5.0
+    - run: echo $LUTHER_LICENSE | base64 -d > .luther-license.yaml
+    - run: make citest

--- a/.github/workflows/substratecommon.yml
+++ b/.github/workflows/substratecommon.yml
@@ -1,4 +1,4 @@
-name: luthersystems/substratecommon/luthersystems/substratecommon
+name: CI Tests
 on:
   push:
     branches:
@@ -12,5 +12,9 @@ jobs:
       image: luthersystems/build-go:0.0.51
     steps:
     - uses: actions/checkout@v3.5.0
-    - run: echo $LUTHER_LICENSE | base64 -d > .luther-license.yaml
-    - run: make citest
+    - name: Set license file
+      run: echo $LUTHER_LICENSE | base64 -d > .luther-license.yaml
+      env:
+        LUTHER_LICENSE: ${{ secrets.LutherLicense }}
+    - name: Run CI tests
+      run: make citest

--- a/.github/workflows/substratecommon.yml
+++ b/.github/workflows/substratecommon.yml
@@ -13,6 +13,6 @@ jobs:
     - name: Set license file
       run: echo $LUTHER_LICENSE | base64 -d > .luther-license.yaml
       env:
-        LUTHER_LICENSE: ${{ secrets.LutherLicense }}
+        LUTHER_LICENSE: ${{ secrets.LUTHER_LICENSE }}
     - name: Run CI tests
       run: make citest

--- a/.github/workflows/substratecommon.yml
+++ b/.github/workflows/substratecommon.yml
@@ -1,10 +1,8 @@
 name: CI Tests
 on:
-  push:
+  pull_request:
     branches:
     - main
-env:
-  LUTHER_LICENSE: xxxxTT0K
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pipeline migrated from [CircleCI](https://app.circleci.com/pipelines/github/luthersystems/substratecommon) :tada:

## Manual steps

Perform the following steps to complete the migration:

### luthersystems/substratecommon/luthersystems/substratecommon
- [ ] Ensure environment variable is updated: `LUTHER_LICENSE`